### PR TITLE
Allow specific time to be used with reminder

### DIFF
--- a/Usami3/commands/remind.js
+++ b/Usami3/commands/remind.js
@@ -1,4 +1,6 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
+const chronify = require("./remind/chronify");
+const friendlyFormat = require("./remind/friendly-format");
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -16,63 +18,27 @@ module.exports = {
 		)
 	,
 	async execute(interaction, data, config, makeEmb) {
-		let remid = interaction.user.id + Date.now().toString();
+		const now = Date.now();
+		let remid = interaction.user.id + now.toString();
 
 		const timeStr = interaction.options.getString("delay");
-		const timeParams = timeStr.split(' ');
-		if (timeParams.length < 2) {
-			interaction.reply(`parse failed. \`${timeParams[0]}\` needs to specify a time period.`)
-			return;
-		}
-
-		let n = parseInt(timeParams[0]);
-		if (isNaN(n)) {
-			if (timeParams[0] === "next") {
-				n = 1;
-			} else {
-				interaction.reply(`parse failed. \`${timeParams[0]}\` is not a number.`);
-				return;
-			}
-		} else if (n < 1) {
-			interaction.reply(`parse failed. \`${timeParams[0]}\` needs to be greater than 0.`);
-			return;
-		}
-		let d = new Date();
-		if (timeParams[1].search(/min/g) > -1) {
-			d.setMinutes(d.getMinutes() + n);
-		} else if (timeParams[1].search(/hour/g) > -1) {
-			d.setHours(d.getHours() + n);
-		} else if (timeParams[1].search(/day/g) > -1) {
-			d.setDate(d.getDate() + n);
-		} else if (timeParams[1].search(/week/g) > -1) {
-			d.setDate(d.getDate() + n * 7);
-		} else if (timeParams[1].search(/month/g) > -1) {
-			if (d.getDate() < 29) {
-				d.setMonth(d.getMonth() + n);
-			} else {
-				//if we're at the end of the month now, make it end of the month next time
-				d.setMonth(d.getMonth() + n);
-				if (d.getDate() < 4) {
-					d.setDate(1 - d.getDate());
-				}
-			}
-		} else if (timeParams[1].search(/year?/g) > -1) {
-			d.setFullYear(d.getFullYear() + n);
-		} else {
-			interaction.reply(`parse failed. \`${timeParams[1]}\` is not a valid timeframe.`);
-			return;
+		const targetDate = chronify(timeStr, now);
+		if (!targetDate) {
+			interaction.reply(`parse failed. \`${timeStr}\` is not a valid time.`);
 		}
 
 		if (data.reminders === undefined) {
 			data.reminders = {};
 		}
 		data.reminders[remid] = {};
-		data.reminders[remid].date = d;
+		data.reminders[remid].date = targetDate;
 		data.reminders[remid].channel = interaction.channel.id;
 		data.reminders[remid].uid = interaction.user.id;
 		data.reminders[remid].text = interaction.options.getString("message");
 
-		interaction.reply(`I have set a reminder for ${n} ${timeParams[1]} from now.`);
+		interaction.reply(
+			`I have set a reminder for ${friendlyFormat(targetDate, now)}.`
+		);
 	},
 
 	repeat(client, data, config) {

--- a/Usami3/commands/remind/chronify.js
+++ b/Usami3/commands/remind/chronify.js
@@ -1,0 +1,37 @@
+const chrono = require("chrono-node");
+const parseDuration = require("parse-duration");
+
+const custom = chrono.casual.clone();
+custom.refiners.push({
+  refine: (context, results) => {
+    // If there is no AM/PM (meridiem) specified, get AM if AM is after now, otherwise get PM
+    results.forEach((result) => {
+      if (
+        !result.start.isCertain("meridiem") &&
+        result.start.isCertain("hour")
+      ) {
+        if (result.start.date() < context.refDate) {
+          result.start.assign("meridiem", 1);
+          result.start.assign("hour", result.start.get("hour") + 12);
+        }
+      }
+    });
+    return results;
+  },
+});
+function chronify(str, now = new Date()) {
+  const preppedInput = _prepInput(str);
+  return custom.parseDate(preppedInput, now, {
+    forwardDate: true,
+  });
+}
+
+function _prepInput(str) {
+  if (parseDuration(str)) {
+    str = str + " from now ";
+  }
+  str = str.replace(/and/g, "");
+  return str;
+}
+
+module.exports = chronify;

--- a/Usami3/commands/remind/friendly-format.js
+++ b/Usami3/commands/remind/friendly-format.js
@@ -1,0 +1,11 @@
+const { format, formatRelative, subDays, addDays } = require("date-fns");
+
+function friendlyFormat(date, now) {
+	if (date > subDays(now, 6) && date < addDays(now, 6)) {
+		return formatRelative(date, now);
+	}
+	// "6 Jan 2020 08:40 PM"
+	return format(date, "d MMM yyyy hh:mm b");
+}
+
+module.exports = friendlyFormat;

--- a/Usami3/package.json
+++ b/Usami3/package.json
@@ -4,7 +4,8 @@
 	"description": "",
 	"main": "main.js",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "jasmine",
+		"watch": "nodemon --exec npm test"
 	},
 	"repository": {
 		"type": "git",
@@ -19,7 +20,14 @@
 	"dependencies": {
 		"@discordjs/builders": "^0.5.0",
 		"@discordjs/rest": "^0.1.0-canary.0",
+		"chrono-node": "^2.5.0",
+		"date-fns": "^2.29.3",
 		"discord-api-types": "^0.22.0",
-		"discord.js": "^13.6.0"
+		"discord.js": "^13.6.0",
+		"parse-duration": "^1.0.2"
+	},
+	"devDependencies": {
+		"jasmine": "^4.5.0",
+		"nodemon": "^2.0.20"
 	}
 }

--- a/Usami3/spec/chronify.spec.js
+++ b/Usami3/spec/chronify.spec.js
@@ -1,0 +1,53 @@
+const chronify = require("../commands/remind/chronify");
+
+describe("Parses date", function () {
+	const now = new Date("2023-02-26 10:20:30");
+
+	it("parses durations correctly", function () {
+		expect(testChronify("10s")).toEqual(new Date("2023-02-26 10:20:40"));
+		expect(testChronify("90 seconds")).toEqual(new Date("2023-02-26 10:22:00"));
+		expect(testChronify("5m")).toEqual(new Date("2023-02-26 10:25:30"));
+		expect(testChronify("in 5m")).toEqual(new Date("2023-02-26 10:25:30"));
+		expect(testChronify("5 mins")).toEqual(new Date("2023-02-26 10:25:30"));
+		expect(testChronify("4h")).toEqual(new Date("2023-02-26 14:20:30"));
+		expect(testChronify("in 4h")).toEqual(new Date("2023-02-26 14:20:30"));
+		expect(testChronify("4 hours from now")).toEqual(new Date("2023-02-26 14:20:30"));
+		expect(testChronify("1 day")).toEqual(new Date("2023-02-27 10:20:30"));
+		expect(testChronify("in 1 week")).toEqual(new Date("2023-03-05 10:20:30"));
+	});
+
+	it("parses mixed durations", function () {
+		expect(testChronify("5h 5m")).toEqual(new Date("2023-02-26 15:25:30"));
+		expect(testChronify("in 5h 5m")).toEqual(new Date("2023-02-26 15:25:30"));
+		expect(testChronify("in 1 week 2 days 3 hours")).toEqual(new Date("2023-03-07 13:20:30"));
+		expect(testChronify("in 1 week 2 days and 3 hours")).toEqual(
+			new Date("2023-03-07 13:20:30")
+		);
+	});
+
+	it("parses decimal durations", function () {
+		expect(testChronify("1.25m")).toEqual(new Date("2023-02-26 10:21:45"));
+		expect(testChronify("5.5 hour")).toEqual(new Date("2023-02-26 15:50:30"));
+	});
+
+	it("parses specific time", function () {
+		expect(testChronify("today at 9")).toEqual(new Date("2023-02-26 21:00:00"));
+		expect(testChronify("today at 11:52")).toEqual(new Date("2023-02-26 11:52:00"));
+		expect(testChronify("today at 18:40")).toEqual(new Date("2023-02-26 18:40:00"));
+		expect(testChronify("6:40 pm today")).toEqual(new Date("2023-02-26 18:40:00"));
+		expect(testChronify("7pm")).toEqual(new Date("2023-02-26 19:00:00"));
+		expect(testChronify("tomorrow")).toEqual(new Date("2023-02-27 10:20:30"));
+		expect(testChronify("friday")).toEqual(new Date("2023-03-03 12:00:00"));
+		expect(testChronify("next friday")).toEqual(new Date("2023-03-03 12:00:00"));
+		expect(testChronify("next week")).toEqual(new Date("2023-03-05 10:20:30"));
+		expect(testChronify("two weeks")).toEqual(new Date("2023-03-12 10:20:30"));
+		expect(testChronify("friday 10am")).toEqual(new Date("2023-03-03 10:00:00"));
+		expect(testChronify("04/01/2023")).toEqual(new Date("2023-04-01 12:00:00"));
+		expect(testChronify("six months from now")).toEqual(new Date("2023-08-26 11:20:30")); // DST!
+		expect(testChronify("a year")).toEqual(new Date("2024-02-26 10:20:30"));
+	});
+
+	function testChronify(str) {
+		return chronify(str, now);
+	}
+});

--- a/Usami3/spec/support/jasmine.json
+++ b/Usami3/spec/support/jasmine.json
@@ -1,0 +1,9 @@
+{
+  "spec_dir": "spec",
+  "spec_files": ["**/*[sS]pec.?(m)js"],
+  "helpers": ["helpers/**/*.?(m)js"],
+  "env": {
+    "stopSpecOnExpectationFailure": false,
+    "random": false
+  }
+}


### PR DESCRIPTION
## Description

This PR allows a user to use the existing `/remind` slash command as follows

```
/remind delay: 6pm message: do something
```

Which will schedule a message at 6pm same day. "Tomorrow", "next week", specific dates and times are supported.

Old duration-based delay like "2 hour" and "1 day" is enhanced to also support "1 day 2 hours", "1.5 hour".

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Added unit tests using Jasmine
- [x] Manual testing in den server